### PR TITLE
pull in the new ruby_block library

### DIFF
--- a/cookbooks/main/libraries/ruby_block.rb
+++ b/cookbooks/main/libraries/ruby_block.rb
@@ -1,40 +1,39 @@
+if Chef::VERSION[/^0.6/]
+  class Chef
+    class Resource
+      class RubyBlock < Chef::Resource
+        def initialize(name, collection = nil, node = nil)
+          super(name, collection, node)
+          @resource_name = :ruby_block
+          @action = :create
+          @allowed_actions.push(:create)
+        end
 
-class Chef
-  class Resource
-    class RubyBlock < Chef::Resource
-      def initialize(name, collection=nil, node=nil)
-        super(name, collection, node)
-        @resource_name = :ruby_block
-        @action = :create
-        @allowed_actions.push(:create)
-      end
- 
-      def block(&block)
-        if block
-          @block = block
-        else
-          @block
+        def block(&block)
+          if block
+            @block = block
+          else
+            @block
+          end
         end
       end
     end
   end
-end
 
+  class Chef
+    class Provider
+      class RubyBlock < Chef::Provider
+        def load_current_resource
+          Chef::Log.debug(@new_resource.inspect)
+          true
+        end
 
-class Chef
-  class Provider
-    class RubyBlock < Chef::Provider
-      def load_current_resource
-        Chef::Log.debug(@new_resource.inspect)
-        true
-      end
- 
-      def action_create
-        @new_resource.block.call
+        def action_create
+          @new_resource.block.call
+        end
       end
     end
   end
+
+  Chef::Platform.platforms[:default][:ruby_block] = Chef::Provider::RubyBlock
 end
-
-Chef::Platform.platforms[:default].merge! :ruby_block => Chef::Provider::RubyBlock
-


### PR DESCRIPTION
passing build in stage



```
/usr/local/ey_resin/ruby/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:55:in `require': iconv will be deprecated in the future, use String#encode instead.
[2017-01-10T10:26:52-08:00] INFO: *** Chef 10.34.6 ***
[2017-01-10T10:26:54-08:00] INFO: Setting the run_list to "recipe[main]" from JSON
[2017-01-10T10:26:54-08:00] INFO: Run List is [recipe[main]]
[2017-01-10T10:26:54-08:00] INFO: Run List expands to [main]
[2017-01-10T10:26:54-08:00] INFO: Starting Chef Run for i-3c2fac36
[2017-01-10T10:26:54-08:00] INFO: Running start handlers
[2017-01-10T10:26:54-08:00] INFO: Start handlers complete.
[2017-01-10T10:26:55-08:00] INFO: Overriding duplicate definition update_file, new definition found in /etc/chef-custom/recipes/cookbooks/main/definitions/update_file.rb
[2017-01-10T10:26:55-08:00] WARN: require_recipe is deprecated and will be removed in a future release, please use include_recipe
[2017-01-10T10:26:55-08:00] WARN: require_recipe is deprecated and will be removed in a future release, please use include_recipe
[2017-01-10T10:26:55-08:00] WARN: require_recipe is deprecated and will be removed in a future release, please use include_recipe
[2017-01-10T10:26:55-08:00] INFO: Processing service[memcached] action nothing (ey_memcached_util::default line 7)
[2017-01-10T10:26:55-08:00] INFO: Processing ban[blacklist] action update (ban::default line 12)
[2017-01-10T10:26:55-08:00] INFO: Running: iptables -A INPUT -s 192.155.83.87 -j DROP -m comment --comment chef
[2017-01-10T10:26:55-08:00] INFO: Processing execute[remove-vm.overcommit_memory-in-sysctl] action run (redis::default line 7)
[2017-01-10T10:26:55-08:00] INFO: execute[remove-vm.overcommit_memory-in-sysctl] ran successfully
[2017-01-10T10:26:55-08:00] INFO: Processing file[add-vm.overcommit_memory-to-sysctl] action create (redis::default line 6)
[2017-01-10T10:26:55-08:00] INFO: Processing ruby_block[append-to-/etc/sysctl.conf] action create (redis::default line 21)
[2017-01-10T10:26:55-08:00] INFO: ruby_block[append-to-/etc/sysctl.conf] called
[2017-01-10T10:26:55-08:00] INFO: Processing execute[reload-sysctl] action run (redis::default line 18)
[2017-01-10T10:26:55-08:00] INFO: execute[reload-sysctl] ran successfully
[2017-01-10T10:26:55-08:00] INFO: Processing file[add dev-db/redis-2.4.6 to /etc/portage/package.keywords/local] action create (redis::default line 6)
[2017-01-10T10:26:55-08:00] INFO: Processing ruby_block[append-to-/etc/portage/package.keywords/local] action create (redis::default line 21)
[2017-01-10T10:26:55-08:00] INFO: Processing package[dev-db/redis] action upgrade (redis::default line 17)
[2017-01-10T10:27:02-08:00] INFO: Processing directory[/data/redis] action create (redis::default line 22)
[2017-01-10T10:27:02-08:00] INFO: Processing template[/etc/redis_util.conf] action create (redis::default line 30)
[2017-01-10T10:27:02-08:00] INFO: Processing template[/data/monit.d/redis_util.monitrc] action create (redis::default line 50)
[2017-01-10T10:27:03-08:00] INFO: template[/data/monit.d/redis_util.monitrc] backed up to /var/chef/backup/data/monit.d/redis_util.monitrc.chef-20170110102703
[2017-01-10T10:27:03-08:00] INFO: template[/data/monit.d/redis_util.monitrc] updated content
[2017-01-10T10:27:03-08:00] INFO: template[/data/monit.d/redis_util.monitrc] owner changed to 0
[2017-01-10T10:27:03-08:00] INFO: template[/data/monit.d/redis_util.monitrc] group changed to 0
[2017-01-10T10:27:03-08:00] INFO: template[/data/monit.d/redis_util.monitrc] mode changed to 644
[2017-01-10T10:27:03-08:00] INFO: Processing execute[monit reload] action run (redis::default line 64)
[2017-01-10T10:27:03-08:00] INFO: execute[monit reload] ran successfully
[2017-01-10T10:27:03-08:00] INFO: Chef Run complete in 8.416597446 seconds
[2017-01-10T10:27:03-08:00] INFO: Running report handlers
[2017-01-10T10:27:03-08:00] INFO: Report handlers complete